### PR TITLE
Fix one instance of parser stuck in infinite loop (OOM) + make `~depth_limit` stricter

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -230,6 +230,8 @@ let token_to_string = function
   | `Char i ->
     char i
 
+  | `String s -> s
+
   | `PI v ->
     signal_to_string (`PI v)
 

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1135,7 +1135,7 @@ let parse ?depth_limit requested_context report (tokens, set_tokenizer_state, se
           | _::ancestors -> iterate' ancestors
         in
         iterate' ancestors
-      | {element_name = _, ("tr" | "th")}::_::_ -> in_cell_mode
+      | {element_name = _, ("td" | "th")}::_::_ -> in_cell_mode
       | {element_name = _, "tr"}::_ -> in_row_mode
       | {element_name = _, ("tbody" | "thead" | "tfoot")}::_ ->
         in_table_body_mode

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -2235,7 +2235,7 @@ let parse ?depth_limit requested_context report (tokens, set_tokenizer_state, se
       in_body_mode_rules "table" mode v
 
     | v ->
-      anything_else_in_table mode v
+      anything_else_in_table in_body_mode v
 
   (* 8.2.5.4.10. *)
   and in_table_text_mode only_space cs mode =

--- a/src/html_tokenizer.ml
+++ b/src/html_tokenizer.ml
@@ -9,6 +9,7 @@ type token =
   | `Start of Token_tag.t
   | `End of Token_tag.t
   | `Char of int
+  | `String of string
   | `Comment of string
   | `EOF ]
 

--- a/src/html_tokenizer.mli
+++ b/src/html_tokenizer.mli
@@ -8,6 +8,7 @@ type token =
   | `Start of Token_tag.t
   | `End of Token_tag.t
   | `Char of int
+  | `String of string
   | `Comment of string
   | `EOF ]
 

--- a/src/markup.ml
+++ b/src/markup.ml
@@ -136,6 +136,13 @@ struct
     Kstream.construct constructor
     |> stream_to_parser
 
+  let parse_tokens ?depth_limit report context tokens =
+    let tokens = Kstream.of_list tokens in
+    let signals =
+      Html_parser.parse ?depth_limit context report (tokens, ignore, ignore)
+    in
+    stream_to_parser signals
+
   let write_html ?escape_attribute ?escape_text signals =
     signals
     |> Html_writer.write ?escape_attribute ?escape_text
@@ -286,6 +293,14 @@ struct
 
     Cps.parse_html (wrap_report report) ?depth_limit ?encoding context source
 
+  let parse_tokens
+      ?(report = fun _ _ -> IO.return ())
+      ?context
+      ?depth_limit
+      tokens =
+
+    Cps.parse_tokens ?depth_limit (wrap_report report) context tokens
+
   let write_html ?escape_attribute ?escape_text signals =
     Cps.write_html ?escape_attribute ?escape_text signals
 
@@ -337,3 +352,12 @@ struct
 end
 
 include Asynchronous (Synchronous)
+
+module Internals = struct
+  include Common
+  module Token_tag = Common.Token_tag
+
+  type token = Html_tokenizer.token
+
+  let parse_tokens = parse_tokens
+end

--- a/src/markup.mli
+++ b/src/markup.mli
@@ -969,3 +969,30 @@ val preprocess_input_stream :
     - HTML: [<html>] tags found in the body do not have their attributes added
       to the [`Start_element "html"] signal emitted at the beginning of the
       document. *)
+
+(* Exposing some internal types and functions to allow sane integration *)
+module Internals : sig
+  type location = int * int
+
+  module Token_tag : sig
+  type t =
+    {name         : string;
+     attributes   : (string * string) list;
+     self_closing : bool}
+  end
+
+    type token =
+  [ `Doctype of doctype
+  | `Start of Token_tag.t
+  | `End of Token_tag.t
+  | `Char of int
+  | `String of string
+  | `Comment of string
+  | `EOF ]
+
+  val parse_tokens :
+  ?report:(location -> Error.t -> unit) ->
+  ?context:[< `Document | `Fragment of string ] ->
+  ?depth_limit:int ->
+  (location * token) list -> 's parser
+end

--- a/test/pages/problem_oom_01
+++ b/test/pages/problem_oom_01
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <body>
+        <form name="form1" method="post" action="mailto:conlegno45@hotmail.com?subject=Reservering van kaarten Jubileumconcert Con Legno 2024" enctype="text/plain">
+            <font size="4">
+                <TABLE BORDER="0" WIDTH="47%"><tr><form></form></tr></table>
+                <table> <tr> <td>some text </tr><tr> <td>some text</td></tr></table>
+            </font>
+        </form>
+        <svg>
+            <path/>
+        </svg>
+    </body>
+</html>

--- a/test/performance/performance_common.ml
+++ b/test/performance/performance_common.ml
@@ -18,7 +18,7 @@ let measure runs library source format f =
 
   Printf.printf "  %s: %.0f us\n" name average
 
-let all_pages = [`Html, "test/pages/google"; `Xml, "test/pages/xml_spec"]
+let all_pages = [`Html, "test/pages/google"; `Xml, "test/pages/xml_spec"; `Html, "test/pages/problem_oom_01"]
 
 let do_full_benchmark ?(runs = 100) ?parse_html ?parse_xml library =
   List.iter 

--- a/test/performance/performance_common.ml
+++ b/test/performance/performance_common.ml
@@ -18,5 +18,11 @@ let measure runs library source format f =
 
   Printf.printf "  %s: %.0f us\n" name average
 
-let google_page = "test/pages/google"
-let xml_spec = "test/pages/xml_spec"
+let all_pages = [`Html, "test/pages/google"; `Xml, "test/pages/xml_spec"]
+
+let do_full_benchmark ?(runs = 100) ?parse_html ?parse_xml library =
+  List.iter 
+    (function
+      | (`Html, page) -> Option.iter (fun f -> measure runs library page "html" (fun () -> f page)) parse_html
+      | (`Xml, page) ->  Option.iter (fun f -> measure runs library page "xml" (fun () -> f page)) parse_xml)
+    all_pages

--- a/test/performance/performance_markup.ml
+++ b/test/performance/performance_markup.ml
@@ -9,6 +9,6 @@ let (|>) x f = f x
 let () =
   do_full_benchmark "markup.ml"
     ~parse_html:(fun page ->
-      file page |> fst |> parse_html |> signals |> drain)
+      file page |> fst |> parse_html ~depth_limit:100 |> signals |> drain)
     ~parse_xml:(fun page ->
       file page |> fst |> parse_xml |> signals |> drain)

--- a/test/performance/performance_markup.ml
+++ b/test/performance/performance_markup.ml
@@ -9,6 +9,6 @@ let (|>) x f = f x
 let () =
   do_full_benchmark "markup.ml"
     ~parse_html:(fun page ->
-      file page |> fst |> parse_html ~depth_limit:100 |> signals |> drain)
+      file page |> fst |> parse_html |> signals |> drain)
     ~parse_xml:(fun page ->
       file page |> fst |> parse_xml |> signals |> drain)

--- a/test/performance/performance_markup.ml
+++ b/test/performance/performance_markup.ml
@@ -7,8 +7,8 @@ open Markup
 let (|>) x f = f x
 
 let () =
-  measure 100 "markup.ml" google_page "html" (fun () ->
-    file google_page |> fst |> parse_html |> signals |> drain);
-
-  measure 100 "markup.ml" xml_spec "xml" (fun () ->
-    file xml_spec |> fst |> parse_xml |> signals |> drain)
+  do_full_benchmark "markup.ml"
+    ~parse_html:(fun page ->
+      file page |> fst |> parse_html |> signals |> drain)
+    ~parse_xml:(fun page ->
+      file page |> fst |> parse_xml |> signals |> drain)

--- a/test/performance/performance_nethtml.ml
+++ b/test/performance/performance_nethtml.ml
@@ -13,9 +13,4 @@ let parse file =
   |> parse_document ~dtd:relaxed_html40_dtd
   |> ignore
 
-let () =
-  measure 100 "nethtml" google_page "html" (fun () ->
-    parse google_page);
-
-  measure 100 "nethtml" xml_spec "html" (fun () ->
-    parse xml_spec)
+let () = do_full_benchmark "nethtml" ~parse_html:parse

--- a/test/performance/performance_xmlm.ml
+++ b/test/performance/performance_xmlm.ml
@@ -15,6 +15,4 @@ let parse file =
     Printf.printf "%i %i %s\n" l c (error_message e);
     raise exn
 
-let () =
-  measure 100 "xmlm" xml_spec "xml" (fun () ->
-    parse xml_spec)
+let () = do_full_benchmark "xmlm" ~parse_xml:parse


### PR DESCRIPTION

Putting this branch on top of <https://github.com/ahrefs/markup.ml/pull/2> to stay compatible.

A problematic test is added as `test/pages/problem_oom_01` (use `( ulimit -v 1000000 ; make performance-test ; )` to preserve sanity).

1. The PR makes the argument `~depth_limit` much stricter (checking every time an element is pushed) ⇒ the above piece of HTML then fails with an exception instead of looping until OOM.
     - Not 100% sure we actually want that, that may be a lot of list traversals.
2. Then there 2 fixes to the parsing of tables:
    - One that was an _“obvious”_ typo — _needle in the CPS-haystack._
    - Another one that makes `problem_oom_01` finish parsing, but I'm not 100% I understand the spec correctly (cf. <https://www.w3.org/TR/2014/CR-html5-20140204/syntax.html#parsing-main-intable> at “Anything else” → it's an error recovery case).

Tried `make performance-test`

- At <https://github.com/ahrefs/markup.ml/pull/2>
- Here, at `fix-html-parser-table-to-body`
- Then adding `~depth_limit:100`

for me `test/pages/google` always oscillates within [1730, 1880] μs

