### PR TITLE
Fix nested form tags handling, stricter limit checks

### DIFF
--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1837,27 +1837,32 @@ let parse ?depth_limit requested_context report (tokens, set_tokenizer_state, se
 
     | l, `End {name = "form"} ->
       if not @@ Stack.has open_elements "template" then begin
-        let form_element = !form_element_pointer in
+        let node = !form_element_pointer in
         form_element_pointer := None;
-        match form_element with
-        | Some element when Stack.target_in_scope open_elements element ->
+        match node with
+        | None ->
+          report l (`Unmatched_end_tag "form") !throw mode
+        | Some element when not (Stack.target_in_scope open_elements element) ->
+          report l (`Unmatched_end_tag "form") !throw mode
+        | Some element -> 
           pop_implied l (fun () ->
           match Stack.current_element open_elements with
           | Some element' when element' == element ->
             pop l mode
           | _ ->
-            report element.location (`Unmatched_start_tag "form") !throw
-              (fun () ->
-            pop_until (fun element' -> element' == element) l (fun () ->
-            pop l mode)))
-        | _ ->
-          report l (`Unmatched_end_tag "form") !throw mode
+            report element.location (`Unmatched_start_tag "form") !throw mode)
       end
-      else
+      else begin
         if not @@ Stack.in_scope open_elements "form" then
           report l (`Unmatched_end_tag "form") !throw mode
         else
-          close_element_with_implied "form" l mode
+          pop_implied l (fun () ->
+            match Stack.current_element open_elements with
+            | Some {element_name = `HTML, "form"} ->
+              pop_until (function {element_name = `HTML, "form"} -> true | _ -> false) l mode
+            | _ ->
+              report l (`Unmatched_end_tag "form") !throw mode)
+      end
 
     | l, `End {name = "p"} ->
       (fun mode' ->
@@ -2227,10 +2232,12 @@ let parse ?depth_limit requested_context report (tokens, set_tokenizer_state, se
       pop l mode))
 
     | l, `Start ({name = "form"} as t) ->
-      misnested_tag l t "table" (fun () ->
-      push_and_emit l t (fun () ->
-      pop l mode))
-
+      if (Stack.has open_elements "template") || !form_element_pointer <> None then
+        misnested_tag l t "table" mode
+      else begin
+        push_and_emit ~set_form_element_pointer:true l t mode;
+        pop l mode
+      end
     | _, `EOF as v ->
       in_body_mode_rules "table" mode v
 

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -2235,7 +2235,7 @@ let parse ?depth_limit requested_context report (tokens, set_tokenizer_state, se
       in_body_mode_rules "table" mode v
 
     | v ->
-      anything_else_in_table in_body_mode v
+      anything_else_in_table mode v
 
   (* 8.2.5.4.10. *)
   and in_table_text_mode only_space cs mode =

--- a/test/pages/problem_oom_01
+++ b/test/pages/problem_oom_01
@@ -3,8 +3,7 @@
     <body>
         <form name="form1" method="post" action="mailto:conlegno45@hotmail.com?subject=Reservering van kaarten Jubileumconcert Con Legno 2024" enctype="text/plain">
             <font size="4">
-                <TABLE BORDER="0" WIDTH="47%"><tr><form></form></tr></table>
-                <table> <tr> <td>some text </tr><tr> <td>some text</td></tr></table>
+                <TABLE><tr><form></form></tr> <tr> <td>some text </tr><tr></tr></table>
             </font>
         </form>
         <svg>

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -1419,6 +1419,16 @@ let tests = [
         1, 13, S  `End_element]
   );
 
+  ("html.parser.form.in-table" >:: fun _ ->
+    expect ~context:(Some (`Fragment "body")) "<form><table><form></table>"
+      [ 1,  1, S (start_element "form");
+        1,  7, S (start_element "table");
+        1, 14, E (`Misnested_tag ("form", "table", []));
+        1, 20, S  `End_element;
+        1, 1, E (`Unmatched_start_tag "form");
+        1, 28, S  `End_element]
+  );
+
   ("html.parser.form.unopened" >:: fun _ ->
     expect ~context:(Some (`Fragment "body")) "</form>"
       [ 1,  1, E (`Unmatched_end_tag "form")]);


### PR DESCRIPTION
In addition to https://github.com/ahrefs/markup.ml/pull/3, this PR 
- fixed nested `<form>` tags handling which could allow parser to return incorrect HTML
- fixed a case where nested `<form>` tags inside a table causing parser to enter infinite loop

